### PR TITLE
【加入】Admin後台users頁面

### DIFF
--- a/controllers/adminUserCtrller.js
+++ b/controllers/adminUserCtrller.js
@@ -1,0 +1,31 @@
+const db = require('../models')
+const User = db.User
+
+const helpers = require('../_helpers')
+
+module.exports = {
+  getUsers: async (req, res) => {
+    try {
+      let [users] = await Promise.all([
+        User.findAll({
+          include: [{ all: true }],
+          order: [['id', 'DESC']],
+        })
+      ])
+
+      users = users.map(user => ({
+        ...user.dataValues,
+        tweetsCount: user.Tweets.length,
+      }))
+
+      users = users.sort((a, b) => b.tweetsCount - a.tweetsCount)
+
+      res.render('admin/users', { users })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json(err.toString())
+    }
+  }
+}
+

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 const tweetsCtrller = require('../controllers/tweetsCtrller')
 const userCtrller = require('../controllers/userCtrller.js')
 const adminTweetsCtrller = require('../controllers/adminTweetsCtrller')
+const adminUserCtrller = require('../controllers/adminUserCtrller')
 
 const { isAuth, isAdminAuth } = require('../middleware/auth')
 
@@ -16,10 +17,12 @@ module.exports = (app, passport) => {
   app.use('/users', isAuth)
   app.get('/users/:id', (req, res) => res.redirect(`/users/${req.params.id}/tweets`))
   app.get('/users/:id/tweets', userCtrller.getUser)
-  
+
   app.use('/admin', isAdminAuth)
   app.get('/admin', (req, res) => res.redirect('/admin/tweets'))
   app.get('/admin/tweets', adminTweetsCtrller.getTweets)
+
+  app.get('/admin/users', adminUserCtrller.getUsers)
 
   app.get('/signup', userCtrller.signUpPage)
   app.post('/signup', userCtrller.signUp)

--- a/views/admin/users.hbs
+++ b/views/admin/users.hbs
@@ -1,0 +1,41 @@
+<div class="mt-5">
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link" href="/admin/tweets">Tweets</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link active" href="/admin/users">Users</a>
+    </li>
+  </ul>
+  <table data-toggle="table" data-search="true" data-show-columns="true">
+    <thead>
+      <tr>
+        <th colspan="2" class="text-center">User</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center">Tweet</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center">Following</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center">Follower</th>
+        <th data-width="150" rowspan="2" data-valign="middle" class="text-center">Like</th>
+      </tr>
+      <tr>
+        <th class="text-center">Avatar</th>
+        <th class="text-center">Name</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each users}}
+        <tr>
+          <td>
+            <a href="/users/{{id}}/tweets">
+              <img src="{{avatar}}" class="img-fluid rounded mx-auto d-block" alt="avatar" style="width: 50px">
+            </a>
+          </td>
+          <td><a href="/users/{{id}}/tweets" class="text-decoration-none text-dark">{{name}}</a></td>
+          <td><a href="/users/{{id}}/tweets" class="text-decoration-none text-dark">{{Tweets.length}}</a></td>
+          <td><a href="/users/{{id}}/followings" class="text-decoration-none text-dark">{{Followings.length}}</a></td>
+          <td><a href="/users/{{id}}/followers" class="text-decoration-none text-dark">{{Followers.length}}</a></td>
+          <td><a href="/users/{{id}}/likes" class="text-decoration-none text-dark">{{LikedTweets.length}}</a></td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
     integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.1/css/all.min.css">
+  <link href="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/css/main.css">
   <title>Simple Twitter</title>
 </head>
@@ -48,6 +49,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
       integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
       crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.js"></script>
   </import>
 </body>
 


### PR DESCRIPTION
<img width="1440" alt="螢幕快照 2019-12-06 下午4 11 37" src="https://user-images.githubusercontent.com/49901777/70307027-33d9ab00-1843-11ea-9b5c-c35d9c4b9076.png">

- 新增admin後台的user頁面：
  - 僅有admin帳號可以進入
  - admin後台分頁改用nav-tab呈現
  - 列出使用者清單，包含Tweet, Following, Follower, Like的數量
  - 點擊使用者或上述幾項可以連結至對應頁面(其他頁面待merge)
  - 使用者清單依照推文數做降冪排序

- 測試部分：
  - 依照PR#19 feedback的部分修改中間件後可以完成測試(uncommit)
<img width="773" alt="螢幕快照 2019-12-06 下午4 10 48" src="https://user-images.githubusercontent.com/49901777/70307366-f6c1e880-1843-11ea-807a-e3cc78bf2007.png">
