### PR TITLE
【加入】 User Followers 頁面

### DIFF
--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -189,7 +189,11 @@ module.exports = {
       // 製作頁面資料
       showedUser.isSelf = (user.id === showedUser.id)
       showedUser.isFollowing = user.Followings.some(following => following.id === showedUser.id)
+
       const followers = showedUser.Followers
+      followers.forEach(follower => {
+        follower.isFollowing = user.Followings.some(following => following.id === follower.id)
+      })
 
       res.render('userFollowers', { css: 'userFollowers', showedUser, followers })
 

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -169,5 +169,33 @@ module.exports = {
       console.error(err)
       res.status(500).json({ status: 'serverError', message: err.toString() })
     }
-  }
+  },
+
+  getFollowers: async (req, res) => {
+    try {
+      const user = helpers.getUser(req)
+      const showedUser = await User.findByPk(req.params.id, {
+        include: [
+          'Followers',
+          // tweets 只用做記數，僅包入 id 來輕量化
+          { model: Tweet, attributes: ['id'] },
+          { association: 'Followings', attributes: ['id'] },
+          { association: 'LikedTweets', attributes: ['id'] }
+        ],
+        // 排序 Followings 藉由 Followship 的 id (最新順)
+        order: [['Followers', Followship, 'id', 'DESC']]
+      })
+
+      // 製作頁面資料
+      showedUser.isSelf = (user.id === showedUser.id)
+      showedUser.isFollowing = user.Followings.some(following => following.id === showedUser.id)
+      const followers = showedUser.Followers
+
+      res.render('userFollowers', { css: 'userFollowers', showedUser, followers })
+
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ status: 'serverError', message: err.toString() })
+    }
+  },
 }

--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -193,6 +193,7 @@ module.exports = {
       const followers = showedUser.Followers
       followers.forEach(follower => {
         follower.isFollowing = user.Followings.some(following => following.id === follower.id)
+        follower.isSelf = (user.id === follower.id)
       })
 
       res.render('userFollowers', { css: 'userFollowers', showedUser, followers })

--- a/public/css/userFollowers.css
+++ b/public/css/userFollowers.css
@@ -1,0 +1,6 @@
+.intro {
+  overflow: hidden;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -21,6 +21,7 @@ module.exports = (app, passport) => {
   app.get('/users/:id/tweets', userCtrller.getUserTweets)
   app.get('/users/:id/edit', userCtrller.editPage)
   app.post('/users/:id/edit', upload.single('image'), userCtrller.postProfile)
+  app.get('/users/:id/followers', userCtrller.getFollowers)
   
   app.use('/admin', isAdminAuth)
   app.get('/admin', (req, res) => res.redirect('/admin/tweets'))

--- a/test/requests/user.spec.js
+++ b/test/requests/user.spec.js
@@ -206,12 +206,12 @@ describe('# user request', () => {
       })
       it('followers list ordered by desc', (done) => {
         request(app)
-          .get('/users/1/followings')
+          .get('/users/1/followers')
           .set('Accept', 'application/json')
           .expect(200)
           .end(function(err, res) {
             if (err) return done(err);
-            res.text.indexOf('User3').should.above(res.text.indexOf('User2'))
+            res.text.indexOf('User2').should.above(res.text.indexOf('User3'))
             return done();
           });
       })

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -9,6 +9,9 @@
     integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.1/css/all.min.css">
   <link rel="stylesheet" href="/css/main.css">
+  {{#if css}}
+    <link rel="stylesheet" href="/css/{{css}}.css">
+  {{/if}}
   <title>Simple Twitter</title>
 </head>
 

--- a/views/partials/userProfile.hbs
+++ b/views/partials/userProfile.hbs
@@ -1,0 +1,37 @@
+<div class="card">
+  <img src="{{showedUser.avatar}}" class="card-img-top" alt="avatar">
+  <div class="card-body">
+    <h5 class="card-title">
+      <a href="/users/{{showedUser.id}}/tweets">{{showedUser.name}}</a>
+    </h5>
+    <p class="card-text">{{showedUser.introduction}}</p>
+  </div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">
+      <a href="/users/{{showedUser.id}}/tweets">Tweets {{showedUser.Tweets.length}}</a>
+    </li>
+    <li class="list-group-item">
+      <a href="/users/{{showedUser.id}}/followings">Following {{showedUser.Followings.length}}</a>
+    </li>
+    <li class="list-group-item">
+      <a href="/users/{{showedUser.id}}/followers">Follower {{showedUser.Followers.length}}</a>
+    </li>
+    <li class="list-group-item">
+      <a href="/users/{{showedUser.id}}/likes">Like {{showedUser.LikedTweets.length}}</a>
+    </li>
+  </ul>
+  <div class="card-body">
+    {{#if showedUser.isSelf}}
+      <a href="/users/{{showedUser.id}}/edit" class="btn btn-primary">Edit Profile</a>
+    {{else if showedUser.isFollowing}}
+      <form action="/followships/{{showedUser.id}}?_method=DELETE" method="POST">
+        <button type="submit" class="btn btn-primary">Following</button>
+      </form>
+    {{else}}
+      <form action="/followships" method="POST">
+        <input type="text" name="id" value="{{showedUser.id}}" hidden>
+        <button type="submit" class="btn btn-outline-primary">Follow</button>
+      </form>
+    {{/if}}
+  </div>
+</div>

--- a/views/userFollowers.hbs
+++ b/views/userFollowers.hbs
@@ -20,7 +20,9 @@
                   </h5>
                   <p class="card-text intro">{{introduction}}</p>
                   <div class="mt-auto">
-                  {{#if isFollowing}}
+                  {{#if isSelf}}
+                    {{!-- 如 follower 是自己，不顯示按鈕 --}}
+                  {{else if isFollowing}}
                     <form action="/followships/{{id}}?_method=DELETE" method="POST" class="text-right">
                       <button type="submit" class="btn btn-primary">Following</button>
                     </form>

--- a/views/userFollowers.hbs
+++ b/views/userFollowers.hbs
@@ -1,0 +1,44 @@
+<div class="row my-5">
+  <aside class="col-5 col-md-3">
+    {{> userProfile}}
+  </aside>
+  {{!-- followers --}}
+  <main class="col-7 col-md-9">
+    <h3>Follower</h3>
+    <div class="row">
+      {{#each followers}}
+        <article class="col-12 col-md-6 mb-4">
+          <div class="card h-100">
+            <div class="row no-gutters h-100">
+              <div class="col-md-4">
+                <img src="{{avatar}}" class="card-img" alt="avatar">
+              </div>
+              <div class="col-md-8">
+                <div class="card-body h-100 d-flex flex-column">
+                  <h5 class="card-title">
+                    <a href="/users/{{id}}/tweets">@{{name}}</a>
+                  </h5>
+                  <p class="card-text intro">{{introduction}}</p>
+                  <div class="mt-auto">
+                  {{#if isFollowing}}
+                    <form action="/followships/{{id}}?_method=DELETE" method="POST" class="text-right">
+                      <button type="submit" class="btn btn-primary">Following</button>
+                    </form>
+                  {{else}}
+                    <form action="/followships" method="POST" class="text-right">
+                      <input type="text" name="id" value="{{id}}" hidden>
+                      <button type="submit" class="btn btn-outline-primary">Follow</button>
+                    </form>
+                  {{/if}}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+      {{/each}}
+    </div>
+  </main>
+</div>
+<br>
+<br>


### PR DESCRIPTION
## Branch 內容
<img src="https://i.gyazo.com/4a69f01a54f4709d2ea84c3d00963252.png" width="300px">

**※ 基本跟 following 一樣**

- User Followers 頁面
  - 相關路由、controller
- 修改 user.spec.js ， `# followers` 錯誤邏輯部分
- 將 profile 側邊攔，拆分成 hbs partials

<br>

## 需確認目標
#### 手動測試
- 可從 User Profile 頁面，點擊左方 Follower 按鈕進入 followers 頁面
- 底部有小留白，頁面不會卡死
<img src="https://i.gyazo.com/20f2c40890f04ec039d4df126509c359.png" width="300px">

- follower 區塊
  - 頁面符合 wireframe，following 呈現雙欄排版
  - 小螢幕時，follower 呈現單欄排版
  - 依最新加入順序排列 (新 follower，顯示在第一個)
  - 可正常操作 follow / unfollow
  - following 卡片均等高，intro 僅顯示 3 行，字數超出者會出現 `...` 刪節號
  - 觀看他人 follower 時，如 follower 是自己，不顯示 follow 按鈕
<img src="https://i.gyazo.com/3ac86b094b221499dabd53546460cd36.png" width="300px">

- profile 區塊
  - profile 從 userFollowers.hbs 頁面拆分為 hbs partial，檔名為 userProfile.hbs
  - Tweet、Following 等計數，有正常顯示
  - 若為使用者自己，顯示 Edit Profile 按鈕
  - 若為別人，顯示 Follow 按鈕，並確認 Follow 功能正常工作

#### mocha 測試
- `test/requests/user.spec.js`
  - `# follower` 子區塊，`go to followers page` 應全數通過
```
// windows 執行
$ SET NODE_ENV=test&& npx mocha test/requests/user.spec.js --exit

// mac 執行
$ NODE_ENV=test npx mocha test/requests/user.spec.js --exit
```