### PR TITLE
【調整】統一各頁面 layout

### DIFF
--- a/controllers/userCtrller.js
+++ b/controllers/userCtrller.js
@@ -113,9 +113,10 @@ module.exports = {
       });
 
       // Following 判斷
-      const isFollowing = user.Followings.some(following => following.id === showedUser.id)
+      showedUser.isFollowing = user.Followings.some(following => following.id === showedUser.id)
+      showedUser.isSelf = (user.id === showedUser.id)
 
-      return res.render('userTweets', { showedUser, tweets, isFollowing })
+      return res.render('userTweets', { showedUser, tweets })
     }
     catch (err) {
       console.error(err)

--- a/views/admin/tweets.hbs
+++ b/views/admin/tweets.hbs
@@ -1,4 +1,4 @@
-<div class="mt-5">
+<main class="col-12">
   <ul class="nav nav-tabs">
     <li class="nav-item">
       <a class="nav-link active" href="/admin/tweets">Tweets</a>
@@ -45,7 +45,7 @@
           </td>
         </tr>
         <!--Reply Modal -->
-        <div class="modal fade" id="ModalScrollable{{this.id}}" tabindex="-1" role="dialog"
+        <main class="modal fade" id="ModalScrollable{{this.id}}" tabindex="-1" role="dialog"
           aria-labelledby="ModalScrollable{{this.id}}Title" aria-hidden="true">
           <div class="modal-dialog modal-dialog-scrollable" role="document">
             <div class="modal-content">
@@ -102,4 +102,4 @@
       {{/each}}
     </tbody>
   </table>
-</div>
+</main>

--- a/views/admin/users.hbs
+++ b/views/admin/users.hbs
@@ -1,4 +1,4 @@
-<div class="mt-5">
+<main class="col-12">
   <ul class="nav nav-tabs">
     <li class="nav-item">
       <a class="nav-link" href="/admin/tweets">Tweets</a>
@@ -38,4 +38,4 @@
       {{/each}}
     </tbody>
   </table>
-</div>
+</main>

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -36,14 +36,18 @@
       </div>
     </div>
   </nav>
-  <div class="container">
+  <div class="container mb-5">
     {{!-- alert flash msg --}}
     <div class="position-relative">
       <span>&nbsp;</span>
       {{> alert}}
     </div>
-    {{{body}}}
+    {{!-- main content --}}
+    <div class="row mt-5">
+      {{{body}}}
+    </div>
   </div>
+  <br>
   <!-- included script -->
   <import>
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"

--- a/views/partials/userProfile.hbs
+++ b/views/partials/userProfile.hbs
@@ -1,12 +1,12 @@
 <div class="card">
   <img src="{{showedUser.avatar}}" class="card-img-top" alt="avatar">
   <div class="card-body">
-    <h5 class="card-title">
+    <h5 class="card-title text-center">
       <a href="/users/{{showedUser.id}}/tweets">{{showedUser.name}}</a>
     </h5>
     <p class="card-text">{{showedUser.introduction}}</p>
   </div>
-  <ul class="list-group list-group-flush">
+  <ul class="list-group list-group-flush text-center">
     <li class="list-group-item">
       <a href="/users/{{showedUser.id}}/tweets">Tweets {{showedUser.Tweets.length}}</a>
     </li>
@@ -20,7 +20,7 @@
       <a href="/users/{{showedUser.id}}/likes">Like {{showedUser.LikedTweets.length}}</a>
     </li>
   </ul>
-  <div class="card-body">
+  <div class="card-body text-center">
     {{#if showedUser.isSelf}}
       <a href="/users/{{showedUser.id}}/edit" class="btn btn-primary">Edit Profile</a>
     {{else if showedUser.isFollowing}}

--- a/views/signin.hbs
+++ b/views/signin.hbs
@@ -1,27 +1,32 @@
-<form class="form-signin mt-5" action="/signin" method="POST">
-  <div class="text-center mb-4">
-    <h1 class="h3 mb-3 font-weight-normal">Sign In</h1>
-  </div>
-  <div class="col-6 mx-auto">
-    <div class="form-label-group mt-2">
-      <label for="inputEmail">
-        <span>Email</span>
-        <span class="text-danger">*</span>
-      </label>
-      <input type="text" name="email" class="form-control" placeholder="Email" autocomplete="email" required autofocus>
+<div class="col-12">
+  <form class="col-md-6 mx-auto" action="/signin" method="POST">
+    <div class="text-center mb-4">
+      <h1 class="h3 mb-3 font-weight-normal">Sign In</h1>
     </div>
-    <div class="form-label-group mt-2">
-      <label for="inputPassword">
-        <span>Password</span>
-        <span class="text-danger">*</span>
-      </label>
-      <input type="password" name="password" class="form-control" placeholder="Password" autocomplete="current-password" required>
+    <div>
+      <div class="form-label-group mt-2">
+        <label for="inputEmail">
+          <span>Email</span>
+          <span class="text-danger">*</span>
+        </label>
+        <input type="text" name="email" class="form-control" placeholder="Email" autocomplete="email" required autofocus>
+      </div>
+      <div class="form-label-group mt-2">
+        <label for="inputPassword">
+          <span>Password</span>
+          <span class="text-danger">*</span>
+        </label>
+        <input type="password" name="password" class="form-control" placeholder="Password" autocomplete="current-password"
+          required>
+      </div>
+      <br />
+      <button class="btn btn-lg btn-primary btn-block" type="submit">Submit</button>
+      <div class="text-center my-4">
+        <p><a href="/signup">Sign up</a></p>
+      </div>
     </div>
-    <br />
-    <button class="btn btn-lg btn-primary btn-block" type="submit">Submit</button>
-    <div class="text-center my-4">
-      <p><a href="/signup">Sign up</a></p>
-    </div>
-  </div>
-  <p class="mt-5 mb-3 text-muted text-center">最終溫蒂蕃茄堡© 2019</p>
-</form>
+  </form>
+</div>
+<div class="col-12 mt-5 text-center">
+  <span class="text-muted">© 2019 最終溫蒂蕃茄堡</span>
+</div>

--- a/views/signup.hbs
+++ b/views/signup.hbs
@@ -1,41 +1,49 @@
-<form class="form-signin mt-5" action="/signup" method="POST">
-  <div class="text-center mb-4">
-    <h1 class="h3 mb-3 font-weight-normal">Sign Up</h1>
-  </div>
-  <div class="col-6 mx-auto">
-    <div class="form-label-group">
-      <label for="inputName">
-        <span>Name</span> 
-        <span class="text-danger">*</span>
-      </label>
-      <input type="text" name="name" class="form-control" placeholder="Name" value="{{input.name}}" autocomplete="username" required autofocus>
+<div class="col-12">
+  <form class="col-md-6 mx-auto" action="/signup" method="POST">
+    <div class="text-center mb-4">
+      <h1 class="h3 mb-3 font-weight-normal">Sign Up</h1>
     </div>
-    <div class="form-label-group mt-2">
-      <label for="inputEmail">
-        <span>Email</span>
-        <span class="text-danger">*</span>
-      </label>
-      <input type="text" name="email" class="form-control" placeholder="Email" value="{{input.email}}" autocomplete="email" required>
+    <div>
+      <div class="form-label-group">
+        <label for="inputName">
+          <span>Name</span>
+          <span class="text-danger">*</span>
+        </label>
+        <input type="text" name="name" class="form-control" placeholder="Name" value="{{input.name}}"
+          autocomplete="username" required autofocus>
+      </div>
+      <div class="form-label-group mt-2">
+        <label for="inputEmail">
+          <span>Email</span>
+          <span class="text-danger">*</span>
+        </label>
+        <input type="text" name="email" class="form-control" placeholder="Email" value="{{input.email}}"
+          autocomplete="email" required>
+      </div>
+      <div class="form-label-group mt-2">
+        <label for="inputPassword">
+          <span>Password</span>
+          <span class="text-danger">*</span>
+        </label>
+        <input type="password" name="password" class="form-control" placeholder="Password" autocomplete="new-password"
+          required>
+      </div>
+      <div class="form-label-group mt-2">
+        <label for="inputPasswordCheck">
+          <span>Password Check</span>
+          <span class="text-danger">*</span>
+        </label>
+        <input type="password" name="passwordCheck" class="form-control" placeholder="Password Check"
+          autocomplete="new-password" required>
+      </div>
+      <br />
+      <button class="btn btn-lg btn-primary btn-block" type="submit">Submit</button>
+      <div class="text-center my-4">
+        <p><a href="/signin">Sign In</a></p>
+      </div>
     </div>
-    <div class="form-label-group mt-2">
-      <label for="inputPassword">
-        <span>Password</span>
-        <span class="text-danger">*</span>
-      </label>
-      <input type="password" name="password" class="form-control" placeholder="Password" autocomplete="new-password" required>
-    </div>
-    <div class="form-label-group mt-2">
-      <label for="inputPasswordCheck">
-        <span>Password Check</span>
-        <span class="text-danger">*</span>
-      </label>
-      <input type="password" name="passwordCheck" class="form-control" placeholder="Password Check" autocomplete="new-password" required>
-    </div>
-    <br />
-    <button class="btn btn-lg btn-primary btn-block" type="submit">Submit</button>
-    <div class="text-center my-4">
-      <p><a href="/signin">Sign In</a></p>
-    </div>
-  </div>
-  <p class="mt-5 mb-3 text-muted text-center">最終溫蒂蕃茄堡© 2019</p>
-</form>
+  </form>
+</div>
+<div class="col-12 mt-5 text-center">
+  <span class="text-muted">© 2019 最終溫蒂蕃茄堡</span>
+</div>

--- a/views/tweets.hbs
+++ b/views/tweets.hbs
@@ -1,85 +1,83 @@
-<div class="row mt-5">
-  <main class="col-8">
-    <section>
-      <form action="" method="POST">
-        <div class="form-group">
-          <textarea class="form-control" name="description" rows="4" required>{{history}}</textarea>
-        </div>
-        <div class="text-right">
-          <button type="submit" class="btn btn-primary">Tweet</button>
-        </div>
-      </form>
-    </section>
-    {{!-- tweets --}}
-    <div class="mt-3">
-      {{#each tweets}}
-        <article>
-          <div class="card mb-3">
-            <div class="row no-gutters">
-              <div class="col-md-4">
-                <a href="/users/{{User.id}}/tweets">
-                  <img src="{{User.avatar}}" class="card-img" alt="avatar">
-                </a>
-              </div>
-              <div class="col-md-8">
-                <div class="card-body">
-                  <h5 class="card-title">
-                    <a href="/users/{{User.id}}/tweets">@{{User.name}}, {{date}}, {{time}}</a>
-                  </h5>
-                  <p class="card-text">{{description}}</p>
-                  <div class="d-flex align-items-center">
-                    <a href="/tweets/{{id}}/replies">Reply({{countReplies}})</a>
-                    {{#if isLike}}
-                      <form action="/tweets/{{id}}/unlike" method="POST" class="d-inline-block">
-                        <button type="submit" class="btn btn-link">Unlike({{countLikes}})</button>
-                      </form>
-                    {{else}}
-                      <form action="/tweets/{{id}}/like" method="POST" class="d-inline-block">
-                        <button type="submit" class="btn btn-link">Like({{countLikes}})</button>
-                      </form>
-                    {{/if}}
-                  </div>
+<main class="col-8">
+  <section>
+    <form action="" method="POST">
+      <div class="form-group">
+        <textarea class="form-control" name="description" rows="4" required>{{history}}</textarea>
+      </div>
+      <div class="text-right">
+        <button type="submit" class="btn btn-primary">Tweet</button>
+      </div>
+    </form>
+  </section>
+  {{!-- tweets --}}
+  <div class="mt-3">
+    {{#each tweets}}
+      <article>
+        <div class="card mb-3">
+          <div class="row no-gutters">
+            <div class="col-md-4">
+              <a href="/users/{{User.id}}/tweets">
+                <img src="{{User.avatar}}" class="card-img" alt="avatar">
+              </a>
+            </div>
+            <div class="col-md-8">
+              <div class="card-body">
+                <h5 class="card-title">
+                  <a href="/users/{{User.id}}/tweets">@{{User.name}}, {{date}}, {{time}}</a>
+                </h5>
+                <p class="card-text">{{description}}</p>
+                <div class="d-flex align-items-center">
+                  <a href="/tweets/{{id}}/replies">Reply({{countReplies}})</a>
+                  {{#if isLike}}
+                    <form action="/tweets/{{id}}/unlike" method="POST" class="d-inline-block">
+                      <button type="submit" class="btn btn-link">Unlike({{countLikes}})</button>
+                    </form>
+                  {{else}}
+                    <form action="/tweets/{{id}}/like" method="POST" class="d-inline-block">
+                      <button type="submit" class="btn btn-link">Like({{countLikes}})</button>
+                    </form>
+                  {{/if}}
                 </div>
               </div>
             </div>
           </div>
-        </article>
-      {{/each}}
-    </div>
-  </main>
-  {{!-- popular users --}}
-  <aside class="col-4">
-    <h3>Popular</h3>
-    {{#each users}}
-      <div class="card mb-3">
-        <div class="row no-gutters">
-          <div class="col-md-4">
-            <a href="/users/{{id}}/tweets">
-              <img src="{{avatar}}" class="card-img" alt="avatar">
-            </a>
-          </div>
-          <div class="col-md-8">
-            <div class="card-body">
-              <h5 class="card-title">
-                <a href="/users/{{id}}/tweets">@{{name}}</a>
-              </h5>
-              <p class="card-text">{{introduction}}</p>
-              {{#if isSelf}}
-                {{!-- 對象是使用者自身，不顯示 follow 按鈕 --}}
-              {{else if isFollowing}}
-                <form action="/followships/{{id}}?_method=DELETE" method="POST" class="text-right">
-                  <button type="submit" class="btn btn-primary">Following</button>
-                </form>
-              {{else}}
-                <form action="/followships" method="POST" class="text-right">
-                  <input type="text" name="id" value="{{id}}" hidden>
-                  <button type="submit" class="btn btn-outline-primary">Follow</button>
-                </form>
-              {{/if}}
-            </div>
+        </div>
+      </article>
+    {{/each}}
+  </div>
+</main>
+{{!-- popular users --}}
+<aside class="col-4">
+  <h3>Popular</h3>
+  {{#each users}}
+    <div class="card mb-3">
+      <div class="row no-gutters">
+        <div class="col-md-4">
+          <a href="/users/{{id}}/tweets">
+            <img src="{{avatar}}" class="card-img" alt="avatar">
+          </a>
+        </div>
+        <div class="col-md-8">
+          <div class="card-body">
+            <h5 class="card-title">
+              <a href="/users/{{id}}/tweets">@{{name}}</a>
+            </h5>
+            <p class="card-text">{{introduction}}</p>
+            {{#if isSelf}}
+              {{!-- 對象是使用者自身，不顯示 follow 按鈕 --}}
+            {{else if isFollowing}}
+              <form action="/followships/{{id}}?_method=DELETE" method="POST" class="text-right">
+                <button type="submit" class="btn btn-primary">Following</button>
+              </form>
+            {{else}}
+              <form action="/followships" method="POST" class="text-right">
+                <input type="text" name="id" value="{{id}}" hidden>
+                <button type="submit" class="btn btn-outline-primary">Follow</button>
+              </form>
+            {{/if}}
           </div>
         </div>
       </div>
-    {{/each}}
-  </aside>
-</div>
+    </div>
+  {{/each}}
+</aside>

--- a/views/userFollowers.hbs
+++ b/views/userFollowers.hbs
@@ -1,46 +1,41 @@
-<div class="row my-5">
-  <aside class="col-5 col-md-3">
-    {{> userProfile}}
-  </aside>
-  {{!-- followers --}}
-  <main class="col-7 col-md-9">
-    <h3>Follower</h3>
-    <div class="row">
-      {{#each followers}}
-        <article class="col-12 col-md-6 mb-4">
-          <div class="card h-100">
-            <div class="row no-gutters h-100">
-              <div class="col-md-4">
-                <img src="{{avatar}}" class="card-img" alt="avatar">
-              </div>
-              <div class="col-md-8">
-                <div class="card-body h-100 d-flex flex-column">
-                  <h5 class="card-title">
-                    <a href="/users/{{id}}/tweets">@{{name}}</a>
-                  </h5>
-                  <p class="card-text intro">{{introduction}}</p>
-                  <div class="mt-auto">
-                  {{#if isSelf}}
-                    {{!-- 如 follower 是自己，不顯示按鈕 --}}
-                  {{else if isFollowing}}
-                    <form action="/followships/{{id}}?_method=DELETE" method="POST" class="text-right">
-                      <button type="submit" class="btn btn-primary">Following</button>
-                    </form>
-                  {{else}}
-                    <form action="/followships" method="POST" class="text-right">
-                      <input type="text" name="id" value="{{id}}" hidden>
-                      <button type="submit" class="btn btn-outline-primary">Follow</button>
-                    </form>
-                  {{/if}}
-                  </div>
+<aside class="col-5 col-md-3">
+  {{> userProfile}}
+</aside>
+<main class="col-7 col-md-9 pl-5">
+  <h3>Follower</h3>
+  <div class="row">
+    {{#each followers}}
+      <article class="col-12 col-md-6 mb-4">
+        <div class="card h-100">
+          <div class="row no-gutters h-100">
+            <div class="col-md-4">
+              <img src="{{avatar}}" class="card-img" alt="avatar">
+            </div>
+            <div class="col-md-8">
+              <div class="card-body h-100 d-flex flex-column">
+                <h5 class="card-title">
+                  <a href="/users/{{id}}/tweets">@{{name}}</a>
+                </h5>
+                <p class="card-text intro">{{introduction}}</p>
+                <div class="mt-auto">
+                {{#if isSelf}}
+                  {{!-- 如 follower 是自己，不顯示按鈕 --}}
+                {{else if isFollowing}}
+                  <form action="/followships/{{id}}?_method=DELETE" method="POST" class="text-right">
+                    <button type="submit" class="btn btn-primary">Following</button>
+                  </form>
+                {{else}}
+                  <form action="/followships" method="POST" class="text-right">
+                    <input type="text" name="id" value="{{id}}" hidden>
+                    <button type="submit" class="btn btn-outline-primary">Follow</button>
+                  </form>
+                {{/if}}
                 </div>
               </div>
             </div>
           </div>
-        </article>
-      {{/each}}
-    </div>
-  </main>
-</div>
-<br>
-<br>
+        </div>
+      </article>
+    {{/each}}
+  </div>
+</main>

--- a/views/userFollowings.hbs
+++ b/views/userFollowings.hbs
@@ -1,46 +1,41 @@
-<div class="row my-5">
-  <aside class="col-5 col-md-3">
-    {{> userProfile}}
-  </aside>
-  {{!-- followings --}}
-  <main class="col-7 col-md-9">
-    <h3>Following</h3>
-    <div class="row">
-      {{#each followings}}
-        <article class="col-12 col-md-6 mb-4">
-          <div class="card h-100">
-            <div class="row no-gutters h-100">
-              <div class="col-md-4">
-                <img src="{{avatar}}" class="card-img" alt="avatar">
-              </div>
-              <div class="col-md-8">
-                <div class="card-body h-100 d-flex flex-column">
-                  <h5 class="card-title">
-                    <a href="/users/{{id}}/tweets">@{{name}}</a>
-                  </h5>
-                  <p class="card-text intro">{{introduction}}</p>
-                  <div class="mt-auto">
-                  {{#if isSelf}}
-                    {{!-- 對象為自己時，不顯示 follow 按鈕 --}}
-                  {{else if isFollowing}}
-                    <form action="/followships/{{id}}?_method=DELETE" method="POST" class="text-right">
-                      <button type="submit" class="btn btn-primary">Following</button>
-                    </form>
-                  {{else}}
-                    <form action="/followships" method="POST" class="text-right">
-                      <input type="text" name="id" value="{{id}}" hidden>
-                      <button type="submit" class="btn btn-outline-primary">Follow</button>
-                    </form>
-                  {{/if}}
-                  </div>
+<aside class="col-5 col-md-3">
+  {{> userProfile}}
+</aside>
+<main class="col-7 col-md-9 pl-5">
+  <h3>Following</h3>
+  <div class="row">
+    {{#each followings}}
+      <article class="col-12 col-md-6 mb-4">
+        <div class="card h-100">
+          <div class="row no-gutters h-100">
+            <div class="col-md-4">
+              <img src="{{avatar}}" class="card-img" alt="avatar">
+            </div>
+            <div class="col-md-8">
+              <div class="card-body h-100 d-flex flex-column">
+                <h5 class="card-title">
+                  <a href="/users/{{id}}/tweets">@{{name}}</a>
+                </h5>
+                <p class="card-text intro">{{introduction}}</p>
+                <div class="mt-auto">
+                {{#if isSelf}}
+                  {{!-- 對象為自己時，不顯示 follow 按鈕 --}}
+                {{else if isFollowing}}
+                  <form action="/followships/{{id}}?_method=DELETE" method="POST" class="text-right">
+                    <button type="submit" class="btn btn-primary">Following</button>
+                  </form>
+                {{else}}
+                  <form action="/followships" method="POST" class="text-right">
+                    <input type="text" name="id" value="{{id}}" hidden>
+                    <button type="submit" class="btn btn-outline-primary">Follow</button>
+                  </form>
+                {{/if}}
                 </div>
               </div>
             </div>
           </div>
-        </article>
-      {{/each}}
-    </div>
-  </main>
-</div>
-<br>
-<br>
+        </div>
+      </article>
+    {{/each}}
+  </div>
+</main>

--- a/views/userLikes.hbs
+++ b/views/userLikes.hbs
@@ -1,82 +1,38 @@
-<div class="row mt-5 no-gutters">
-  {{!-- user profile --}}
-  <aside class="col-4 ">
-    <div class="row mt-3">
-      <div class="card col-8">
-        <img src="{{showedUser.avatar}}" class="card-img-top" alt="avatar">
-        <div class="card-body">
-          <h5 class="card-title">
-            <a href="/users/{{showedUser.id}}/tweets">{{showedUser.name}}</a>
-          </h5>
-          <p class="card-text">{{showedUser.introduction}}</p>
-        </div>
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/tweets">Tweets {{showedUser.Tweets.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/followings">Following {{showedUser.Followings.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/followers">Follower {{showedUser.Followers.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/likes">Like {{showedUser.LikedTweets.length}}</a>
-          </li>
-        </ul>
-        <div class="card-body">
-          {{#if showedUser.isSelf}}
-          <a href="/users/{{showedUser.id}}/edit" class="btn btn-primary">Edit Profile</a>
-          {{else if showedUser.isFollowing}}
-          <form action="/followships/{{showedUser.id}}?_method=DELETE" method="POST">
-            <button type="submit" class="btn btn-primary">Following</button>
-          </form>
-          {{else}}
-          <form action="/followships" method="POST">
-            <input type="text" name="id" value="{{showedUser.id}}" hidden>
-            <button type="submit" class="btn btn-outline-primary">Follow</button>
-          </form>
-          {{/if}}
-        </div>
-      </div>
-    </div>
-  </aside>
-  {{!-- tweets --}}
-  <main class="col-8 ">
-    <h3>Like</h3>
-    {{#each showedTweet}}
-    <div class=" mt-3">
-      <article>
-        <div class="card mb-3">
-          <div class="row no-gutters">
-            <div class="col-md-4 ">
-              <img src="{{this.User.avatar}}" class="card-img" alt="avatar">
-            </div>
-            <div class="col-md-8">
-              <div class="card-body">
-                <h5 class="card-title">
-                  <a href="/users/{{this.User.id}}/tweets">@{{this.User.name}} ,{{this.date}},
-                    {{this.time}}</a>
-                </h5>
-                <p class="card-text">{{this.description}}</p>
-                <div class="d-flex align-items-center">
-                  <a href="/tweets/{{this.id}}/replies">Reply({{this.countReplies}})</a>
-                  {{#if isLiked}}
-                  <form action="/tweets/{{this.id}}/unlike" method="POST" class="d-inline-block">
-                    <button type="submit" class="btn btn-link">Unlike({{this.countLikes}})</button>
-                  </form>
-                  {{else}}
-                  <form action="/tweets/{{this.id}}/like" method="POST" class="d-inline-block">
-                    <button type="submit" class="btn btn-link">Like({{this.countLikes}})</button>
-                  </form>
-                  {{/if}}
-                </div>
+<aside class="col-5 col-md-3">
+  {{> userProfile}}
+</aside>
+<main class="col-7 col-md-9 pl-5">
+  <h3>Like</h3>
+  {{#each showedTweet}}
+    <article>
+      <div class="card mb-3">
+        <div class="row no-gutters">
+          <div class="col-md-4 ">
+            <img src="{{this.User.avatar}}" class="card-img" alt="avatar">
+          </div>
+          <div class="col-md-8">
+            <div class="card-body">
+              <h5 class="card-title">
+                <a href="/users/{{this.User.id}}/tweets">@{{this.User.name}} ,{{this.date}},
+                  {{this.time}}</a>
+              </h5>
+              <p class="card-text">{{this.description}}</p>
+              <div class="d-flex align-items-center">
+                <a href="/tweets/{{this.id}}/replies">Reply({{this.countReplies}})</a>
+                {{#if isLiked}}
+                <form action="/tweets/{{this.id}}/unlike" method="POST" class="d-inline-block">
+                  <button type="submit" class="btn btn-link">Unlike({{this.countLikes}})</button>
+                </form>
+                {{else}}
+                <form action="/tweets/{{this.id}}/like" method="POST" class="d-inline-block">
+                  <button type="submit" class="btn btn-link">Like({{this.countLikes}})</button>
+                </form>
+                {{/if}}
               </div>
             </div>
           </div>
         </div>
-      </article>
-    </div>
-    {{/each}}
-  </main>
-</div>
+      </div>
+    </article>
+  {{/each}}
+</main>

--- a/views/userReplies.hbs
+++ b/views/userReplies.hbs
@@ -2,58 +2,64 @@
   {{> userProfile}}
 </aside>
 <main class="col-7 col-md-9 pl-5">
-  <h3>Tweets</h3>
-  <article>
-    <div class="card mb-3">
-      <div class="row no-gutters">
-        <div class="col-md-4 ">
-          <img src="{{showedUser.avatar}}" class="card-img" alt="avatar">
-        </div>
-        <div class="col-md-8">
-          <div class="card-body">
-            <h5 class="card-title">
-              <a href="/users/{{showedUser.id}}/tweets">@{{showedUser.name}} ,{{showedTweet.date}},
-                {{showedTweet.time}}</a>
-            </h5>
-            <p class="card-text">{{showedTweet.description}}</p>
-            <div class="d-flex align-items-center">
-              <a href="/tweets/{{showedTweet.id}}/replies">Reply({{showedTweet.countReplies}})</a>
-              {{#if showedTweet.isLiked}}
-              <form action="/tweets/{{showedTweet.id}}/unlike" method="POST" class="d-inline-block">
-                <button type="submit" class="btn btn-link">Unlike({{showedTweet.countLikes}})</button>
-              </form>
-              {{else}}
-              <form action="/tweets/{{showedTweet.id}}/like" method="POST" class="d-inline-block">
-                <button type="submit" class="btn btn-link">Like({{showedTweet.countLikes}})</button>
-              </form>
-              {{/if}}
+  {{!-- Tweet --}}
+  <section>
+    <h3>Tweet</h3>
+    <article>
+      <div class="card mb-3">
+        <div class="row no-gutters">
+          <div class="col-md-4 ">
+            <img src="{{showedUser.avatar}}" class="card-img" alt="avatar">
+          </div>
+          <div class="col-md-8">
+            <div class="card-body">
+              <h5 class="card-title">
+                <a href="/users/{{showedUser.id}}/tweets">@{{showedUser.name}} ,{{showedTweet.date}},
+                  {{showedTweet.time}}</a>
+              </h5>
+              <p class="card-text">{{showedTweet.description}}</p>
+              <div class="d-flex align-items-center">
+                <a href="/tweets/{{showedTweet.id}}/replies">Reply({{showedTweet.countReplies}})</a>
+                {{#if showedTweet.isLiked}}
+                  <form action="/tweets/{{showedTweet.id}}/unlike" method="POST" class="d-inline-block">
+                    <button type="submit" class="btn btn-link">Unlike({{showedTweet.countLikes}})</button>
+                  </form>
+                {{else}}
+                  <form action="/tweets/{{showedTweet.id}}/like" method="POST" class="d-inline-block">
+                    <button type="submit" class="btn btn-link">Like({{showedTweet.countLikes}})</button>
+                  </form>
+                {{/if}}
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </article>
-  {{!-- replies --}}
-  <h3>Replies</h3>
-  {{#each replies}}
-  <article>
-    <div class="card mb-3">
-      <div class="row no-gutters">
-        <div class="col-md-4 ">
-          <img src="{{this.User.avatar}}" class="card-img" alt="avatar">
-        </div>
-        <div class="col-md-8">
-          <div class="card-body">
-            <h5 class="card-title">
-              <a href="/users/{{this.UserId}}/tweets">@{{this.User.name}} ,{{this.date}},{{this.time}}</a>
-            </h5>
-            <p class="card-text">{{this.comment}}</p>
+    </article>
+  </section>
+  {{!-- Replies --}}
+  <section>
+    <h3>Replies</h3>
+    {{#each replies}}
+      <article>
+        <div class="card mb-3">
+          <div class="row no-gutters">
+            <div class="col-md-4 ">
+              <img src="{{this.User.avatar}}" class="card-img" alt="avatar">
+            </div>
+            <div class="col-md-8">
+              <div class="card-body">
+                <h5 class="card-title">
+                  <a href="/users/{{this.UserId}}/tweets">@{{this.User.name}} ,{{this.date}},{{this.time}}</a>
+                </h5>
+                <p class="card-text">{{this.comment}}</p>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
-  </article>
-  {{/each}}
+      </article>
+    {{/each}}
+  </section>
+  {{!-- Reply Form --}}
   <section>
     <form action="/tweets/{{showedTweet.id}}/replies" method="POST">
       <div class="form-group">

--- a/views/userReplies.hbs
+++ b/views/userReplies.hbs
@@ -1,115 +1,68 @@
-<div class="row mt-5 no-gutters">
-  {{!-- user profile --}}
-  <aside class="col-4 ">
-    <div class="row mt-3">
-      <div class="card col-8">
-        <img src="{{showedUser.avatar}}" class="card-img-top" alt="avatar">
-        <div class="card-body">
-          <h5 class="card-title">
-            <a href="/users/{{showedUser.id}}/tweets">{{showedUser.name}}</a>
-          </h5>
-          <p class="card-text">{{showedUser.introduction}}</p>
+<aside class="col-5 col-md-3">
+  {{> userProfile}}
+</aside>
+<main class="col-7 col-md-9 pl-5">
+  <h3>Tweets</h3>
+  <article>
+    <div class="card mb-3">
+      <div class="row no-gutters">
+        <div class="col-md-4 ">
+          <img src="{{showedUser.avatar}}" class="card-img" alt="avatar">
         </div>
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/tweets">Tweets {{showedUser.Tweets.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/followings">Following {{showedUser.Followings.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/followers">Follower {{showedUser.Followers.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/likes">Like {{showedUser.LikedTweets.length}}</a>
-          </li>
-        </ul>
-        <div class="card-body">
-          {{#if showedUser.isSelf}}
-          <a href="/users/{{showedUser.id}}/edit" class="btn btn-primary">Edit Profile</a>
-          {{else if showedUser.isFollowing}}
-          <form action="/followships/{{showedUser.id}}?_method=DELETE" method="POST">
-            <button type="submit" class="btn btn-primary">Following</button>
-          </form>
-          {{else}}
-          <form action="/followships" method="POST">
-            <input type="text" name="id" value="{{showedUser.id}}" hidden>
-            <button type="submit" class="btn btn-outline-primary">Follow</button>
-          </form>
-          {{/if}}
+        <div class="col-md-8">
+          <div class="card-body">
+            <h5 class="card-title">
+              <a href="/users/{{showedUser.id}}/tweets">@{{showedUser.name}} ,{{showedTweet.date}},
+                {{showedTweet.time}}</a>
+            </h5>
+            <p class="card-text">{{showedTweet.description}}</p>
+            <div class="d-flex align-items-center">
+              <a href="/tweets/{{showedTweet.id}}/replies">Reply({{showedTweet.countReplies}})</a>
+              {{#if showedTweet.isLiked}}
+              <form action="/tweets/{{showedTweet.id}}/unlike" method="POST" class="d-inline-block">
+                <button type="submit" class="btn btn-link">Unlike({{showedTweet.countLikes}})</button>
+              </form>
+              {{else}}
+              <form action="/tweets/{{showedTweet.id}}/like" method="POST" class="d-inline-block">
+                <button type="submit" class="btn btn-link">Like({{showedTweet.countLikes}})</button>
+              </form>
+              {{/if}}
+            </div>
+          </div>
         </div>
       </div>
     </div>
-  </aside>
-
-  <main class="col-8 ">
-    {{!-- tweets --}}
-    <h3>Tweets</h3>
-    <div class=" mt-3">
-      <article>
-        <div class="card mb-3">
-          <div class="row no-gutters">
-            <div class="col-md-4 ">
-              <img src="{{showedUser.avatar}}" class="card-img" alt="avatar">
-            </div>
-            <div class="col-md-8">
-              <div class="card-body">
-                <h5 class="card-title">
-                  <a href="/users/{{showedUser.id}}/tweets">@{{showedUser.name}} ,{{showedTweet.date}},
-                    {{showedTweet.time}}</a>
-                </h5>
-                <p class="card-text">{{showedTweet.description}}</p>
-                <div class="d-flex align-items-center">
-                  <a href="/tweets/{{showedTweet.id}}/replies">Reply({{showedTweet.countReplies}})</a>
-                  {{#if showedTweet.isLiked}}
-                  <form action="/tweets/{{showedTweet.id}}/unlike" method="POST" class="d-inline-block">
-                    <button type="submit" class="btn btn-link">Unlike({{showedTweet.countLikes}})</button>
-                  </form>
-                  {{else}}
-                  <form action="/tweets/{{showedTweet.id}}/like" method="POST" class="d-inline-block">
-                    <button type="submit" class="btn btn-link">Like({{showedTweet.countLikes}})</button>
-                  </form>
-                  {{/if}}
-                </div>
-              </div>
-            </div>
+  </article>
+  {{!-- replies --}}
+  <h3>Replies</h3>
+  {{#each replies}}
+  <article>
+    <div class="card mb-3">
+      <div class="row no-gutters">
+        <div class="col-md-4 ">
+          <img src="{{this.User.avatar}}" class="card-img" alt="avatar">
+        </div>
+        <div class="col-md-8">
+          <div class="card-body">
+            <h5 class="card-title">
+              <a href="/users/{{this.UserId}}/tweets">@{{this.User.name}} ,{{this.date}},{{this.time}}</a>
+            </h5>
+            <p class="card-text">{{this.comment}}</p>
           </div>
         </div>
-      </article>
+      </div>
     </div>
-    {{!-- replies --}}
-    <h3>Replies</h3>
-    <div class=" mt-3">
-      {{#each replies}}
-      <article>
-        <div class="card mb-3">
-          <div class="row no-gutters">
-            <div class="col-md-4 ">
-              <img src="{{this.User.avatar}}" class="card-img" alt="avatar">
-            </div>
-            <div class="col-md-8">
-              <div class="card-body">
-                <h5 class="card-title">
-                  <a href="/users/{{this.UserId}}/tweets">@{{this.User.name}} ,{{this.date}},{{this.time}}</a>
-                </h5>
-                <p class="card-text">{{this.comment}}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </article>
-      {{/each}}
-    </div>
-    <section>
-      <form action="/tweets/{{showedTweet.id}}/replies" method="POST">
-        <div class="form-group">
-          <textarea class="form-control" name="comment" id="comment" rows="4"></textarea>
-        </div>
-        <input type="hidden" name="TweetId" value="{{showedTweet.id}}">
-        <div class="text-right">
-          <button type="submit" class="btn btn-primary">Reply</button>
-        </div>
-      </form>
-    </section>
-  </main>
-</div>
+  </article>
+  {{/each}}
+  <section>
+    <form action="/tweets/{{showedTweet.id}}/replies" method="POST">
+      <div class="form-group">
+        <textarea class="form-control" name="comment" id="comment" rows="4"></textarea>
+      </div>
+      <input type="hidden" name="TweetId" value="{{showedTweet.id}}">
+      <div class="text-right">
+        <button type="submit" class="btn btn-primary">Reply</button>
+      </div>
+    </form>
+  </section>
+</main>

--- a/views/userTweets.hbs
+++ b/views/userTweets.hbs
@@ -1,80 +1,37 @@
-<div class="row mt-5 no-gutters">
-  {{!-- user profile --}}
-  <aside class="col-4 ">
-    <div class="row mt-3">
-      <div class="card col-8">
-        <img src="{{showedUser.avatar}}" class="card-img-top" alt="avatar">
-        <div class="card-body">
-          <h5 class="card-title">
-            <a href="/users/{{showedUser.id}}/tweets">{{showedUser.name}}</a>
-          </h5>
-          <p class="card-text">{{showedUser.introduction}}</p>
-        </div>
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/tweets">Tweets {{tweets.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/followings">Following {{showedUser.Followings.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/followers">Follower {{showedUser.Followers.length}}</a>
-          </li>
-          <li class="list-group-item">
-            <a href="/users/{{showedUser.id}}/likes">Like {{showedUser.LikedTweets.length}}</a>
-          </li>
-        </ul>
-        <div class="card-body">
-          {{#ifEquals showedUser.id user.id}}
-            <a href="/users/{{showedUser.id}}/edit" class="btn btn-primary">Edit Profile</a>
-          {{else if isFollowing}}
-            <form action="/followships/{{showedUser.id}}?_method=DELETE" method="POST">
-              <button type="submit" class="btn btn-primary">Following</button>
-            </form>
-          {{else}}
-            <form action="/followships" method="POST">
-              <input type="text" name="id" value="{{showedUser.id}}" hidden>
-              <button type="submit" class="btn btn-outline-primary">Follow</button>
-            </form>
-          {{/ifEquals}}
-        </div>
-      </div>
-    </div>
-  </aside>
-  {{!-- tweets --}}
-  <main class="col-8 ">
-    {{#each tweets}}
-    <div class=" mt-3">
-      <article>
-        <div class="card mb-3">
-          <div class="row no-gutters">
-            <div class="col-md-4 ">
-              <img src="{{../showedUser.avatar}}" class="card-img" alt="avatar">
-            </div>
-            <div class="col-md-8">
-              <div class="card-body">
-                <h5 class="card-title">
-                  <a href="/users/{{../showedUser.id}}/tweets">@{{../showedUser.name}} ,{{this.date}}, {{this.time}}</a>
-                </h5>
-                <p class="card-text">{{this.description}}</p>
-                <div class="d-flex align-items-center">
-                  <a href="/tweets/{{this.id}}/replies">Reply({{this.countReplies}})</a>
-                  {{#if isLiked}}
-                  <form action="/tweets/{{this.id}}/unlike" method="POST" class="d-inline-block">
-                    <button type="submit" class="btn btn-link">Unlike({{this.countLikes}})</button>
-                  </form>
-                  {{else}}
-                  <form action="/tweets/{{this.id}}/like" method="POST" class="d-inline-block">
-                    <button type="submit" class="btn btn-link">Like({{this.countLikes}})</button>
-                  </form>
-                  {{/if}}
-                </div>
+<aside class="col-5 col-md-3">
+  {{> userProfile}}
+</aside>
+<main class="col-7 col-md-9 pl-5">
+  <h3>Tweet</h3>
+  {{#each tweets}}
+    <article>
+      <div class="card mb-3">
+        <div class="row no-gutters">
+          <div class="col-md-4 ">
+            <img src="{{../showedUser.avatar}}" class="card-img" alt="avatar">
+          </div>
+          <div class="col-md-8">
+            <div class="card-body">
+              <h5 class="card-title">
+                <a href="/users/{{../showedUser.id}}/tweets">@{{../showedUser.name}} ,{{this.date}}, {{this.time}}</a>
+              </h5>
+              <p class="card-text">{{this.description}}</p>
+              <div class="d-flex align-items-center">
+                <a href="/tweets/{{this.id}}/replies">Reply({{this.countReplies}})</a>
+                {{#if isLiked}}
+                <form action="/tweets/{{this.id}}/unlike" method="POST" class="d-inline-block">
+                  <button type="submit" class="btn btn-link">Unlike({{this.countLikes}})</button>
+                </form>
+                {{else}}
+                <form action="/tweets/{{this.id}}/like" method="POST" class="d-inline-block">
+                  <button type="submit" class="btn btn-link">Like({{this.countLikes}})</button>
+                </form>
+                {{/if}}
               </div>
             </div>
           </div>
         </div>
-      </article>
-    </div>
-    {{/each}}
-  </main>
-</div>
+      </div>
+    </article>
+  {{/each}}
+</main>

--- a/views/userTweets.hbs
+++ b/views/userTweets.hbs
@@ -2,7 +2,7 @@
   {{> userProfile}}
 </aside>
 <main class="col-7 col-md-9 pl-5">
-  <h3>Tweet</h3>
+  <h3>Tweets</h3>
   {{#each tweets}}
     <article>
       <div class="card mb-3">


### PR DESCRIPTION
- User 頁面格局統一
  - user profile 使用 partials 模塊化
  - user 相關頁面配合 profile 全局調整
- 底部留白效果，統一到 main layout
- 頂部預留給 alert 的 mt-5，統一到 main layout
- 除 admin 外，所有頁面最父層皆為 .row 排版，因此統一到 main layout
- 配合 main layout 改動，調整所有頁面

## 需確認項
- 各頁面的主內容 `{{body}}` 與 navbar 之間的留白高度，應該相等
- 各頁面的底部留白高度，應該相等
- user 相關頁面，layout 應該一致 (Tweets、Followings...... 等頁面，切換時版型不會跳動)