### PR TITLE
【優化】後台Admin UI

### DIFF
--- a/controllers/adminTweetsCtrller.js
+++ b/controllers/adminTweetsCtrller.js
@@ -2,6 +2,7 @@ const db = require('../models')
 const { User, Tweet, Reply } = db
 
 const helpers = require('../_helpers')
+const moment = require('moment')
 
 module.exports = {
   getTweets: async (req, res) => {
@@ -9,19 +10,24 @@ module.exports = {
       const [tweets] = await Promise.all([
         Tweet.findAll({
           order: [['id', 'DESC']],
-          include: [User, { model: Reply, order: [['id', 'ASC']] }]
+          include: [User, { model: Reply, order: [['id', 'ASC']], include: [User] }]
         })
       ])
 
       tweets.forEach(tweet => {
-        tweet.date = tweet.createdAt.toLocaleDateString()
-        tweet.time = tweet.createdAt.toLocaleTimeString().slice(0, -6)
+        tweet.date = moment(tweet.createdAt).format('lll')
+        tweet.time = moment(tweet.createdAt).fromNow(false)
         if (tweet.description.length > 50) {
           tweet.shortenDescript = tweet.description.slice(0, 50) + ' ...'
         } else {
           tweet.shortenDescript = tweet.description
         }
+        tweet.Replies.forEach(reply => {
+          reply.date = moment(reply.createdAt).format('lll')
+          reply.time = moment(reply.createdAt).fromNow(false)
+        })
       })
+      console.log(tweets[1].Replies[0])
 
       res.render('admin/tweets', { tweets, adminNavbar: true })
 

--- a/controllers/adminTweetsCtrller.js
+++ b/controllers/adminTweetsCtrller.js
@@ -27,7 +27,6 @@ module.exports = {
           reply.time = moment(reply.createdAt).fromNow(false)
         })
       })
-      console.log(tweets[1].Replies[0])
 
       res.render('admin/tweets', { tweets, adminNavbar: true })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "test",
+  "name": "burger_twitter",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -142,11 +142,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "aws-sign": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
-      "integrity": "sha1-xVAThWyBlOyFSgy+yQqrWgTOOsU="
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -204,14 +199,6 @@
         "qs": "6.5.2",
         "raw-body": "2.3.3",
         "type-is": "~1.6.16"
-      }
-    },
-    "boom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
-      "integrity": "sha1-yM2wQUNZEnQWKMBE7Mcy0dF8Ceo=",
-      "requires": {
-        "hoek": "0.7.x"
       }
     },
     "brace-expansion": {
@@ -444,11 +431,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
-    "cookie-jar": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
-      "integrity": "sha1-ZOzAasl423leS1KQy+SLo3gUAPo="
-    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -474,14 +456,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
       "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms="
-    },
-    "cryptiles": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
-      "integrity": "sha1-GlVnNPBtJLo0hirpy55wmjr7/xw=",
-      "requires": {
-        "boom": "0.3.x"
-      }
     },
     "d": {
       "version": "1.0.1",
@@ -880,11 +854,6 @@
         "is-buffer": "~2.0.3"
       }
     },
-    "forever-agent": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
-      "integrity": "sha1-4cJcetROCcOPIzh2x2/MJP+EOx8="
-    },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -1028,26 +997,10 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
-    "hawk": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
-      "integrity": "sha1-mzYd7pWpMWQObVBOBWCaj8OsRdI=",
-      "requires": {
-        "boom": "0.3.x",
-        "cryptiles": "0.1.x",
-        "hoek": "0.7.x",
-        "sntp": "0.1.x"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-    },
-    "hoek": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
-      "integrity": "sha1-YPvZBFV1Qc0rh5Wr8wihs3cOFVo="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -1139,14 +1092,6 @@
             "safe-buffer": "^5.0.1"
           }
         }
-      }
-    },
-    "imgur-node-api": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/imgur-node-api/-/imgur-node-api-0.1.0.tgz",
-      "integrity": "sha1-iJU25/x9/FyYXHtVeMGuwxyzwYY=",
-      "requires": {
-        "request": "~2.16.6"
       }
     },
     "inflection": {
@@ -1291,11 +1236,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
-      "integrity": "sha1-nbew5TDH8onF6MhDKvGRwv91pbM="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -1526,9 +1466,9 @@
       }
     },
     "moment": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
       "version": "0.5.23",
@@ -1659,11 +1599,6 @@
         "abbrev": "1",
         "osenv": "^0.1.4"
       }
-    },
-    "oauth-sign": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
-      "integrity": "sha1-oOahcV2u0GLzIrYit/5a/RA1tuI="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1931,69 +1866,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
-    "request": {
-      "version": "2.16.6",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
-      "integrity": "sha1-hy/kRa5y3iZrN4edatfclI+gHK0=",
-      "requires": {
-        "aws-sign": "~0.2.0",
-        "cookie-jar": "~0.2.0",
-        "forever-agent": "~0.2.0",
-        "form-data": "~0.0.3",
-        "hawk": "~0.10.2",
-        "json-stringify-safe": "~3.0.0",
-        "mime": "~1.2.7",
-        "node-uuid": "~1.4.0",
-        "oauth-sign": "~0.2.0",
-        "qs": "~0.5.4",
-        "tunnel-agent": "~0.2.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-          "requires": {
-            "delayed-stream": "0.0.5"
-          }
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
-        },
-        "form-data": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
-          "integrity": "sha1-2zRaU3jYau6x7V1VO4aawZLS9e0=",
-          "requires": {
-            "async": "~0.2.7",
-            "combined-stream": "~0.0.4",
-            "mime": "~1.2.2"
-          }
-        },
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "qs": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-          "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q="
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2170,14 +2042,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
       "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA=="
-    },
-    "sntp": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
-      "integrity": "sha1-XvSBuVGnspr/30r9fyaDj8ESD4Q=",
-      "requires": {
-        "hoek": "0.7.x"
-      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -2372,11 +2236,6 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
-    },
-    "tunnel-agent": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
-      "integrity": "sha1-aFPCr7GyEJ5FYp5JK9419Fnqaeg="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "imgur": "^0.3.1",
     "method-override": "^3.0.0",
     "mocha": "^6.0.2",
+    "moment": "^2.24.0",
     "multer": "^1.4.2",
     "mysql2": "^1.6.4",
     "passport": "^0.4.0",

--- a/views/admin/tweets.hbs
+++ b/views/admin/tweets.hbs
@@ -105,8 +105,8 @@
                 </button>
               </div>
               <div class="modal-body">
-                <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title"><i class="fas fa-quote-left"></i>
-                  {{description}} <i class="fas fa-quote-right"></i></h5>
+                <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                  {{description}}</h5>
                 </br>
                 <h5 class="text-danger text-right">你真的要刪除這則推文嗎？</h5>
               </div>

--- a/views/admin/tweets.hbs
+++ b/views/admin/tweets.hbs
@@ -23,12 +23,13 @@
         <tr>
           <td>
             <a href="/users/{{User.id}}/tweets">
-              <img src="{{User.avatar}}" class="img-fluid rounded mx-auto d-block" alt="avatar" style="width: 50px">
+              <img src="{{User.avatar}}" title="{{User.name}}" class="img-fluid rounded mx-auto d-block" alt="avatar"
+                style="width: 50px">
             </a>
           </td>
           <td>{{id}}</td>
           <td>{{shortenDescript}}</td>
-          <td>{{date}} {{time}}</td>
+          <td title="{{this.date}}">{{time}}</td>
           <td>
             <!-- Reply Button trigger modal -->
             <button type="button" class="btn btn-outline-secondary" data-toggle="modal"
@@ -51,19 +52,39 @@
             <div class="modal-content">
               <div class="modal-header d-flex align-items-center">
                 <a href="/users/{{User.id}}/tweets">
-                  <img src="{{User.avatar}}" class="img-fluid rounded mx-auto d-block" alt="avatar" style="width: 50px">
+                  <img src="{{User.avatar}}" class="img-fluid rounded mx-auto d-block" alt="avatar" style="width: 60px">
                 </a>
-                <h5 class="ml-2">{{User.name}}</h5>
+                <div class="md-1">
+                  <a href="/users/{{User.id}}/tweets" class="text-dark">
+                    <h5 class="ml-2">{{User.name}}</h5>
+                  </a>
+                  <h6 class="ml-2" title="{{this.date}}">{{this.time}}</h6>
+                </div>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
                 </button>
               </div>
               <div class="modal-body">
-                <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title"><i class="fas fa-quote-left"></i>
-                  {{description}} <i class="fas fa-quote-right"></i></h5>
-                </br>
+                <h5 class="modal-title ml-3" id="ModalScrollable{{this.id}}Title">
+                  {{description}} </h5>
+                <hr style="border-top: 3px double #e8e8e8;">
                 {{#each this.Replies}}
-                  <p><i class="fas fa-angle-right"></i> {{this.comment}}</p>
+                  <div class="ml-3">
+                    <div class="row ml-1">
+                      <a href="/users/{{User.id}}/tweets">
+                        <img src="{{User.avatar}}" class="img-fluid rounded mx-auto d-block" alt="avatar"
+                          style="width: 50px">
+                      </a>
+                      <div>
+                        <a href="/users/{{User.id}}/tweets" class="text-dark">
+                          <h5 class="ml-2">{{User.name}}</h5>
+                        </a>
+                        <h6 class="ml-2" title="{{this.date}}">{{this.time}}</h6>
+                      </div>
+                    </div>
+                    <p>{{this.comment}}</p>
+                  </div>
+                  <hr>
                 {{/each}}
               </div>
               <div class="modal-footer">

--- a/views/admin/users.hbs
+++ b/views/admin/users.hbs
@@ -26,14 +26,19 @@
         <tr>
           <td>
             <a href="/users/{{id}}/tweets">
-              <img src="{{avatar}}" class="img-fluid rounded mx-auto d-block" alt="avatar" style="width: 50px">
+              <img src="{{avatar}}" title="{{name}}" class="img-fluid rounded mx-auto d-block" alt="avatar"
+                style="width: 50px">
             </a>
           </td>
-          <td><a href="/users/{{id}}/tweets" class="text-decoration-none text-dark">{{name}}</a></td>
-          <td><a href="/users/{{id}}/tweets" class="text-decoration-none text-dark">{{Tweets.length}}</a></td>
-          <td><a href="/users/{{id}}/followings" class="text-decoration-none text-dark">{{Followings.length}}</a></td>
-          <td><a href="/users/{{id}}/followers" class="text-decoration-none text-dark">{{Followers.length}}</a></td>
-          <td><a href="/users/{{id}}/likes" class="text-decoration-none text-dark">{{LikedTweets.length}}</a></td>
+          <td><a href="/users/{{id}}/tweets" class="text-decoration-none text-dark d-block">{{name}}</a></td>
+          <td><a href="/users/{{id}}/tweets" class="text-decoration-none text-dark d-block py-3">{{Tweets.length}}</a>
+          </td>
+          <td><a href="/users/{{id}}/followings"
+              class="text-decoration-none text-dark d-block py-3">{{Followings.length}}</a></td>
+          <td><a href="/users/{{id}}/followers"
+              class="text-decoration-none text-dark d-block py-3">{{Followers.length}}</a></td>
+          <td><a href="/users/{{id}}/likes"
+              class="text-decoration-none text-dark d-block py-3">{{LikedTweets.length}}</a></td>
         </tr>
       {{/each}}
     </tbody>


### PR DESCRIPTION
### User頁面
- 調整各個計數器連結的點擊範圍(整個表格都可以點擊)
- 頭像補上title顯示名稱(雖然隔壁就有)
<img width="1440" alt="螢幕快照 2019-12-08 上午1 41 04" src="https://user-images.githubusercontent.com/49901777/70378502-f61c7580-195b-11ea-82d4-e44066eef0bb.png">

### Tweet頁面
- 頭像補上title顯示名稱
- 引入moment，時間改為顯示相對時間
- 相對時間補上title顯示完整時間
- 調整modal UI，區隔主文與回覆
- 增加reply與user關聯，modal中可以顯示回覆相關使用者與時間
<img width="1440" alt="螢幕快照 2019-12-08 上午1 21 12" src="https://user-images.githubusercontent.com/49901777/70378562-c91c9280-195c-11ea-9050-a06e9a7420f9.png">


